### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
  <img src="https://img.shields.io/badge/Node.js-43853D?style=flat&logo=node.js&logoColor=white"/>
  <img src="https://img.shields.io/badge/MCP-Server-blue?style=flat"/>
  <img src="https://img.shields.io/badge/License-MIT-brightgreen?style=flat"/>
+<a href="https://smithery.ai/server/@chanmeng666/google-jobs-server"><img alt="Smithery Badge" src="https://smithery.ai/badge/@chanmeng666/google-jobs-server"></a>
 </div>
 
 <br/>
@@ -126,6 +127,14 @@ npm start
 - Verify country/language code support
 
 # 📦 Installation
+
+## Installing via Smithery
+
+To install Google Jobs for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@chanmeng666/google-jobs-server):
+
+```bash
+npx -y @smithery/cli install @chanmeng666/google-jobs-server --client claude
+```
 
 ## Manual Installation
 


### PR DESCRIPTION
This PR makes two updates to the README for the Google Jobs MCP server.

1. **Installation Instructions Added**: New section for installing Google Jobs for Claude Desktop using the Smithery CLI. This simplifies the installation process for users by automating it with a single command.
2. **Smithery Badge Included**: A badge has been added to display the number of installations via Smithery, providing users with a quick view of adoption metrics: https://smithery.ai/server/@chanmeng666/google-jobs-server

Feel free to request any further changes!