### PR TITLE
feat - e2e tests + evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,15 @@ yarn add @chanmeng666/google-jobs-server
 pnpm add @chanmeng666/google-jobs-server
 ```
 
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/index.ts
+```
 # 💻 Tech Stack
 
 ![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.1.1",
+    "mcp-evals": "^1.0.18",
     "node-fetch": "^3.3.2"
   },
   "devDependencies": {

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -1,0 +1,23 @@
+//evals.ts
+
+import { EvalConfig } from 'mcp-evals';
+import { openai } from "@ai-sdk/openai";
+import { grade, EvalFunction } from "mcp-evals";
+
+const search_jobsEval: EvalFunction = {
+    name: "search_jobsEval",
+    description: "Evaluates the jobs search functionality",
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Find me data analyst jobs in Tokyo posted this week with at least a $100K salary.");
+        return JSON.parse(result);
+    }
+};
+
+const config: EvalConfig = {
+    model: openai("gpt-4"),
+    evals: [search_jobsEval]
+};
+  
+export default config;
+  
+export const evals = [search_jobsEval];


### PR DESCRIPTION
Adds new e2e test that loads an MCP client, which in turn runs the server and processes the actual tool call. Afterwards, it then grades the response for correctness. 

note: I'm the package author 